### PR TITLE
Deploy update

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,51 +1,64 @@
-# Simple workflow for deploying static content to GitHub Pages
-name: Build and deploy
+# Nom du workflow qui apparaîtra dans l'onglet "Actions" de GitHub
+name: Build and Deploy Docusaurus to GitHub Pages
 
 on:
-  # Runs on pushes targeting the default branch
+  # Se déclenche à chaque push sur la branche "main"
   push:
     branches: ["main"]
 
-  # Allows you to run this workflow manually from the Actions tab
+  # Permet de lancer ce workflow manuellement depuis l'onglet "Actions"
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+# Définit les permissions nécessaires pour que le workflow puisse déployer sur GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+# Empêche les déploiements concurrents pour éviter les conflits
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
 jobs:
-  # Single deploy job since we're just deploying
+  # Le seul job de ce workflow : construire et déployer
   deploy:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
+      # 1. Récupère le code de votre dépôt
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup Python
-        uses: actions/setup-python@v5.2.0
+
+      # 2. Met en place Node.js (l'environnement de Docusaurus)
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18' # Utilise une version stable de Node.js
+          cache: 'npm'       # Met en cache les dépendances pour accélérer les builds futurs
+
+      # 3. Installe les dépendances du projet
       - name: Install dependencies
-        run: |
-          pip install --upgrade pip
-          pip install -r requirements.txt
+        run: npm ci # 'ci' est plus rapide et plus sûr pour l'intégration continue que 'install'
+
+      # 4. Construit le site Docusaurus
       - name: Build site
-        run: mkdocs build
+        run: npm run build # C'est la commande standard de Docusaurus
+
+      # 5. Configure GitHub Pages pour recevoir le site
       - name: Setup Pages
         uses: actions/configure-pages@v5
+
+      # 6. Prépare le dossier du site construit pour le déploiement
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload entire repository
-          path: './site'
+          # Le résultat de `npm run build` est dans le dossier 'build'
+          path: './build'
+
+      # 7. Déploie le site sur GitHub Pages
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm install rss-parser turndown axios
 ## Local Development
 
 ```bash
-yarn start
+npm run start
 ```
 
 This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
@@ -31,7 +31,8 @@ This command starts a local development server and opens up a browser window. Mo
 ## Build
 
 ```bash
-yarn build
+npm run build
+npm run serve
 ```
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -14,7 +14,7 @@ const config: Config = {
   },
 
   // Set the production url of your site here
-  url: 'https://docs.paxo.fr',
+  url: 'docs.paxo.fr',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: '/',


### PR DESCRIPTION
This pull request updates the project to use Docusaurus (a Node.js-based static site generator) instead of MkDocs (a Python-based tool), and adapts the build and deployment workflow accordingly. It also updates documentation and configuration to reflect these changes.

**Build and Deployment Workflow Modernization:**

* [`.github/workflows/build-and-deploy.yml`](diffhunk://#diff-ecad2183af1362d9d99f4a33e7491c1970c92255c3c318e688ece549ec91fe33L1-R61): Replaces the MkDocs/Python-based deployment with a Docusaurus/Node.js workflow, including updated steps for installing Node.js dependencies, building with Docusaurus, and deploying the `build` directory to GitHub Pages. The workflow steps and comments are now also in French.

**Documentation Updates:**

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L26-R35): Updates development and build instructions to use `npm` commands (`npm run start`, `npm run build`, `npm run serve`) instead of `yarn`, aligning with the move to a Node.js-based setup.

**Configuration Adjustment:**

* [`docusaurus.config.ts`](diffhunk://#diff-cc8abb6104e21d495dc8f64639c7b03419226d920d1c545df51be9b0b73b2784L17-R17): Changes the `url` configuration from `https://docs.paxo.fr` to `docs.paxo.fr`, which may be necessary for correct GitHub Pages deployment.